### PR TITLE
Ability to filter notifications by a single permission

### DIFF
--- a/SlackNotifications/SlackNotifications.php
+++ b/SlackNotifications/SlackNotifications.php
@@ -243,7 +243,7 @@ function slack_file_uploaded($image)
 		round($image->getLocalFile()->size / 1024 / 1024, 3),
             $image->getLocalFile()->getDescription());
 
-	push_slack_notify($message, "green", $user);
+	push_slack_notify($message, "green", $wgUser);
 	return true;
 }
 

--- a/SlackNotifications/SlackNotificationsDefaultConfig.php
+++ b/SlackNotifications/SlackNotificationsDefaultConfig.php
@@ -38,6 +38,8 @@ if (!isset($hpc_attached)) die();
 	$wgSlackIncludeUserUrls = true;
 	// If this is true, all minor edits made to articles will not be submitted to Slack.
 	$wgSlackIgnoreMinorEdits = false;
+	// If this is set, actions by users with this permission won't cause alerts
+	$wgExcludedPermission = "";
 	
 ##################
 # MEDIAWIKI URLS #


### PR DESCRIPTION
For my wikis (wikis.paradoxplaza.com) I saw the need to filter out trusted users, as otherwise the number of notifications would be immense (couple hundred each day).
So I added in the ability to exclude users with a specified user permission for my own version. Thought it might be useful to have it in the main branch as well.