### PR TITLE
Added size of diff

### DIFF
--- a/SlackNotifications/SlackNotificationsDefaultConfig.php
+++ b/SlackNotifications/SlackNotificationsDefaultConfig.php
@@ -86,4 +86,6 @@ if (!isset($hpc_attached)) die();
 	$wgSlackNotificationEditedArticle = true;
 	// File uploaded
 	$wgSlackNotificationFileUpload = true;
+	// Include the size of the diff when pages are edited
+	$wgSlackIncludeDiffSize = true;
 ?>


### PR DESCRIPTION
Now it'll optionally (on by default) show the size of diffs and newly created pages.
Didn't see a good way to show the size of _deleted_ pages, though I'm sure there must be one.

Now looks like this:
![image](https://cloud.githubusercontent.com/assets/4614118/18233467/8a02063e-72e8-11e6-8259-a434fc27db18.png)

I also added a linebreak between the user/page line and the edit summary as that looks a bit cleaner.