### PR TITLE
moved message text to message attachment text

### DIFF
--- a/SlackNotifications/SlackNotificationsCore.php
+++ b/SlackNotifications/SlackNotificationsCore.php
@@ -310,9 +310,9 @@ class SlackNotifications
 			$slackFromName = $wgSitename;
 		}
 		
-		$post = sprintf('payload={"text": "%s", "username": "%s",'.$optionalChannel.' "attachments": [ { "color": "%s" } ]',
-		urlencode($message),
+		$post = sprintf('payload={"username": "%s",'.$optionalChannel.' "attachments": [ { "text": "%s", "color": "%s" } ]',
 		urlencode($slackFromName),
+		urlencode($message),
 		urlencode($slackColor));
 		if ( $wgSlackEmoji != "" )
 		{


### PR DESCRIPTION
fixed attachment color bar in slack by adding the message text to the attachment instead of the message, this also fixes the display style for mattermost