### PR TITLE
Fixed crash when users submit an edit with no changes

### DIFF
--- a/SlackNotifications/SlackNotificationsCore.php
+++ b/SlackNotifications/SlackNotificationsCore.php
@@ -115,6 +115,11 @@ class SlackNotifications
 		// Skip minor edits if user wanted to ignore them
 		if ($isMinor && $wgSlackIgnoreMinorEdits) return;
 		
+		if ( $article->getRevision()->getPrevious() == NULL )
+		{
+			return; // Skip edits that are just refreshing the page
+		}
+		
 		$message = sprintf(
 			"%s has %s article %s %s",
 			self::getSlackUserText($user),


### PR DESCRIPTION
If someone hits "Save" without making any changes, Slack Notifications is currently triggered. However, since this has no previous revision, since nothing changed, Slack Notifications crashes and displays an error.

I've fixed this by having it simply do nothing in this case, since such null edits have no effect other than clearing out the cache for the page.